### PR TITLE
Ditching interpax and have cubic spline implemented in utils.py

### DIFF
--- a/jesterTOV/utils.py
+++ b/jesterTOV/utils.py
@@ -13,7 +13,6 @@ from jax import vmap
 import jax.numpy as jnp
 from functools import partial
 from jaxtyping import Array, Float, Int
-from interpax._spline import interp1d as interpax_interp1d
 
 from diffrax import diffeqsolve, ODETerm, Tsit5, SaveAt, PIDController
 
@@ -287,18 +286,33 @@ def limit_by_MTOV(
 
 def cubic_spline(xq: Float[Array, "n"], xp: Float[Array, "n"], fp: Float[Array, "n"]):
     r"""
-    Cubic spline interpolation using interpax.
+    Local cubic Hermite spline interpolation.
 
-    This function creates a cubic spline interpolator through the given
-    data points and evaluates it at the query points. Cubic splines
-    provide smooth interpolation with continuous first and second derivatives.
+    Builds a piecewise cubic through the data points that is continuous in
+    value and first derivative (:math:`C^1`), and evaluates it at the query
+    points. The node derivatives are estimated by finite differences of the
+    segment slopes,
+
+    .. math::
+        d_j = \frac{f_{j+1} - f_j}{x_{j+1} - x_j},
+
+    with the interior derivatives given by the average of the adjacent slopes
+    and the endpoint derivatives by the one-sided slope:
+
+    .. math::
+        f'_0 = d_0, \qquad
+        f'_j = \tfrac{1}{2}\left(d_{j-1} + d_j\right), \qquad
+        f'_{N-1} = d_{N-2}.
+
+    On each interval the cubic Hermite basis is evaluated in the local
+    coordinate :math:`t = (x_q - x_{i-1}) / (x_i - x_{i-1})`.
 
     Parameters
     ----------
     xq : Float[Array, "n"]
         Query points for evaluation
     xp : Float[Array, "n"]
-        Known x-coordinates of data points
+        Known x-coordinates of data points, in ascending order
     fp : Float[Array, "n"]
         Known y-coordinates, i.e., fp = f(xp)
 
@@ -309,10 +323,34 @@ def cubic_spline(xq: Float[Array, "n"], xp: Float[Array, "n"], fp: Float[Array, 
 
     Notes
     -----
-    Uses the interpax library for JAX-compatible spline interpolation.
-    See: https://github.com/f0uriest/interpax
+    This is a local scheme: each interval depends only on its four
+    neighbouring data points, so no linear system is solved and the result is
+    cheap to evaluate, differentiate and JIT-compile. It is only
+    :math:`C^1`, not :math:`C^2`, unlike a global natural spline.
+
+    Query points outside ``[xp[0], xp[-1]]`` are extrapolated with the cubic
+    of the nearest interval rather than being flagged, so accuracy degrades
+    quickly away from the data range.
     """
-    return interpax_interp1d(xq, xp, fp, method="cubic")
+    dx = jnp.diff(xp)
+    slopes = jnp.diff(fp) / dx
+    dfp = jnp.concatenate([slopes[:1], 0.5 * (slopes[:-1] + slopes[1:]), slopes[-1:]])
+
+    i = jnp.clip(jnp.searchsorted(xp, xq, side="right"), 1, len(xp) - 1)
+    h = xp[i] - xp[i - 1]
+    t = (xq - xp[i - 1]) / h
+
+    f0, f1 = fp[i - 1], fp[i]
+    m0, m1 = dfp[i - 1] * h, dfp[i] * h
+
+    t2 = t * t
+    t3 = t2 * t
+    return (
+        (2.0 * t3 - 3.0 * t2 + 1.0) * f0
+        + (t3 - 2.0 * t2 + t) * m0
+        + (-2.0 * t3 + 3.0 * t2) * f1
+        + (t3 - t2) * m1
+    )
 
 
 def sigmoid(x: Array) -> Array:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "jaxtyping",
     "diffrax",
     "optax<0.2.7",
-    "interpax",
     "flowjax<18.0.0",
     "typing_extensions>=4.5.0",
     "pydantic>=2.0",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 """Unit tests for utils module."""
 
 import pytest
+import jax
 import jax.numpy as jnp
 from hypothesis import given, strategies as st
 from jesterTOV import utils
@@ -67,6 +68,46 @@ class TestInterpolationFunctions:
 
         # Should be close to true sine function
         assert jnp.mean(jnp.abs(result - expected)) < 0.1
+
+    def test_cubic_spline_passes_through_knots(self):
+        """Test that the spline reproduces the data at the knots."""
+        xp = jnp.linspace(0, 2 * jnp.pi, 15)
+        fp = jnp.sin(xp)
+
+        result = utils.cubic_spline(xp, xp, fp)
+
+        assert jnp.allclose(result, fp, atol=1e-12)
+
+    def test_cubic_spline_nonuniform_grid(self):
+        """Test interpolation on a log-spaced grid, as used for the EOS."""
+        xp = jnp.logspace(-3, 0, 60)
+        xq = jnp.linspace(xp[0], xp[-1], 200)
+
+        result = utils.cubic_spline(xq, xp, jnp.exp(-xp))
+
+        assert jnp.max(jnp.abs(result - jnp.exp(-xq))) < 1e-3
+
+    def test_cubic_spline_reproduces_cubic(self):
+        """Test that a cubic polynomial is recovered to high accuracy."""
+        poly = lambda x: 2.0 * x**3 - 1.5 * x**2 + 0.5 * x + 3.0
+        xp = jnp.linspace(-2.0, 2.0, 40)
+        xq = jnp.linspace(-1.5, 1.5, 100)
+
+        result = utils.cubic_spline(xq, xp, poly(xp))
+
+        assert jnp.max(jnp.abs(result - poly(xq))) < 1e-3
+
+    def test_cubic_spline_jit_and_grad(self):
+        """Test that the spline is JIT-compilable and differentiable."""
+        xp = jnp.linspace(0, 2 * jnp.pi, 12)
+        fp = jnp.sin(xp)
+        xq = jnp.linspace(0.1, 2 * jnp.pi - 0.1, 30)
+
+        jitted = jax.jit(utils.cubic_spline)(xq, xp, fp)
+        assert jnp.allclose(jitted, utils.cubic_spline(xq, xp, fp))
+
+        grad = jax.grad(lambda f: jnp.sum(utils.cubic_spline(xq, xp, f)))(fp)
+        assert jnp.all(jnp.isfinite(grad))
 
 
 class TestCumtrapz:

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1167,22 +1167,6 @@ wheels = [
 ]
 
 [[package]]
-name = "interpax"
-version = "0.3.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "equinox" },
-    { name = "jax" },
-    { name = "jaxtyping" },
-    { name = "lineax" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/39/55576cf2c33c1f4df483ec1507fb36027389c00863772b78abf04c75afff/interpax-0.3.12.tar.gz", hash = "sha256:9563b5458a70a9bac34372c68d8fca34a03864e19805b06763a1c48dbd420699", size = 58170, upload-time = "2025-11-03T19:01:45.591Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/41/2077ef0c346d44ec66d1ee807493631fbe07e6088255191b4324fc258949/interpax-0.3.12-py3-none-any.whl", hash = "sha256:1f447c238ae629dabf23f9c04671d52a03d11251f31ec7607556c576a81142b6", size = 27795, upload-time = "2025-11-03T19:01:44.422Z" },
-]
-
-[[package]]
 name = "ipykernel"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1394,7 +1378,6 @@ dependencies = [
     { name = "flowjax" },
     { name = "flowmc" },
     { name = "h5py" },
-    { name = "interpax" },
     { name = "ipython" },
     { name = "jax" },
     { name = "jaxlib" },
@@ -1463,7 +1446,6 @@ requires-dist = [
     { name = "flowmc", specifier = "==0.4.5" },
     { name = "h5py", specifier = ">=3.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "interpax" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "ipython", specifier = ">=8.0" },
     { name = "jax", specifier = ">=0.4.20,<0.8.0" },
@@ -3224,23 +3206,23 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -3256,23 +3238,23 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -3305,7 +3287,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
 wheels = [
@@ -3321,7 +3303,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/51/6603ed3786a2d52366c66f49bc8afb31ae5c0e33d4a156afcb38d2bac62c/sphinx_autodoc_typehints-3.6.2.tar.gz", hash = "sha256:3d37709a21b7b765ad6e20a04ecefcb229b9eb0007cb24f6ebaa8a4576ea7f06", size = 37574, upload-time = "2026-01-02T21:25:28.216Z" }
 wheels = [
@@ -3859,9 +3841,9 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
-    { name = "scipy", marker = "python_full_version < '3.12'" },
-    { name = "xarray", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "xarray" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/10/ef474494a7f2102ec4c02352c723fa282c6237b600565eb82ee354291211/xarray_einstats-0.9.1.tar.gz", hash = "sha256:39b373deed43592c41d3fbf8863af62e19e01c1ae553ae5ff059a8df78d995c6", size = 33327, upload-time = "2025-06-18T15:53:28.499Z" }
 wheels = [
@@ -3877,9 +3859,9 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
-    { name = "scipy", marker = "python_full_version >= '3.12'" },
-    { name = "xarray", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "xarray" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/9b/305ee6a2dac75fc9c28105db061408df6ecbf0f7a1de37636e8e4ea47ca7/xarray_einstats-0.10.0.tar.gz", hash = "sha256:d432a363fc8f09baad164f9826dc711551c684b9abd8098c1b961d18663a627d", size = 33449, upload-time = "2026-02-19T18:13:55.245Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Drops the `interpax` dependency. We only used `interp1d(..., method="cubic")`, via a private import (`interpax._spline`), from a single call site (`eos/metamodel/base.py:402`). That function is now implemented directly in `utils.cubic_spline`.

One behavioural difference: interpax returns NaN outside the data range; the new function extrapolates with the nearest interval's cubic. The only call site queries strictly inside the data range, so nothing is affected. Documented in the docstring.

## Changes

- `jesterTOV/utils.py` - reimplement `cubic_spline`, drop the import
- `pyproject.toml` / `uv.lock` - remove the dependency (interpax is the only package dropped, no version bumps)
- `tests/test_utils.py` - four new tests: knot reproduction, log-spaced grid, cubic-polynomial recovery, jit/grad

## Verification

Ran both implementations side by side. Spline output agrees to 0-25 ulp across random non-uniform grids, log-spaced grids, exact cubics, and edge cases (queries at knots, at endpoints, N=3). EOS quantities agree to 3.9e-16, i.e. 1-2 ulp.

712 tests pass, pyright clean, pre-commit clean. Strict Sphinx not run locally (`pandoc` missing); building with notebooks excluded showed no warnings from the new docstring.

## Note for reviewers

M/R/Lambda differ by up to 1.2e-3 in Lambda. This is not the spline: nudging interpax's own output by one ulp reproduces bit-identical downstream deviations. It is the adaptive Diffrax stepper choosing a different step sequence from a last-bit input change. Worth knowing separately from this PR, since it means `construct_family` is only reproducible to ~1e-3 in Lambda.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved cubic spline interpolation for more consistent results across uniform and nonuniform data grids.
  - Added robust handling for values outside the defined range through nearest-interval extrapolation.
  - Preserved compatibility with JIT compilation and automatic differentiation workflows.
  - Spline results now maintain continuous first derivatives, with enhanced accuracy for cubic polynomial inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->